### PR TITLE
fix(RegistryClient): convert hash to version map to array

### DIFF
--- a/src/registry/RegistryClient.ts
+++ b/src/registry/RegistryClient.ts
@@ -231,7 +231,8 @@ export class RegistryClient extends HTTPClient<RegistryError> {
                 hashes,
                 algorithm: "sha512",
             }),
-        }).then(res => res.json());
+        }).then(res => res.json())
+            .then((json: Record<string, RegistryVersion>) => Object.values(json));
     }
 
     /**


### PR DESCRIPTION
The hash can be obtained from the version files.